### PR TITLE
Adding Tag Attributes to the contextmenu-layer and Ability to Add Multiple "className" to menu-item.

### DIFF
--- a/src/contextmenu-layer.js
+++ b/src/contextmenu-layer.js
@@ -63,14 +63,14 @@ export default function(identifier, configure) {
             },
             render: function() {
 
-                var attributeArray = tagAttributes.toAttributeArray(this.props.attributes);
+                var attributes = this.props.attributes;
                 var classNames = tagAttributes.getClassNames(this.props.attributes);
 
                 //Make sure to add the react-context-menu-wrapper information
-                attributeArray["className"] = "react-context-menu-wrapper" + classNames;
-                attributeArray["onContextMenu"] = this.handleContextClick;
+                attributes["className"] = "react-context-menu-wrapper" + classNames;
+                attributes["onContextMenu"] = this.handleContextClick;
 
-                return React.createElement(this.props.renderTag, attributeArray, React.createElement(Component, this.props));
+                return React.createElement(this.props.renderTag, attributes, React.createElement(Component, this.props));
             }
         });
     };

--- a/src/contextmenu-layer.js
+++ b/src/contextmenu-layer.js
@@ -59,11 +59,41 @@ export default function(identifier, configure) {
                     }
                 });
             },
-            render() {
-                return React.createElement(this.props.renderTag, {
-                    className: "react-context-menu-wrapper",
-                    onContextMenu: this.handleContextClick
-                }, React.createElement(Component, this.props));
+            toAttributeArray: function(attributes){
+
+                var attributeArray = [];
+                for(var key in attributes){
+                    if(attributes.hasOwnProperty(key)){
+                        attributeArray[key] = attributes[key];
+                    }
+                }
+                return attributeArray;
+            },
+            getClassNames: function(attributes){
+
+                var classNames = "";
+                for(var key in attributes){
+                    if(attributes.hasOwnProperty(key)){
+                        if(key == "className"){
+                            classNames = classNames + " " + attributes[key];
+                        }
+                    }
+                }
+                return classNames;
+            },
+            render: function() {
+
+                var attributes = this.props.attributes;
+                if(attributes == undefined) attributes = {};
+
+                var attributeArray = this.toAttributeArray(attributes);
+                var classNames = this.getClassNames(attributes);
+
+                //Make sure to add the react-context-menu-wrapper information
+                attributeArray["className"] = "react-context-menu-wrapper" + classNames;
+                attributeArray["onContextMenu"] = this.handleContextClick;
+
+                return React.createElement(this.props.renderTag, attributeArray, React.createElement(Component, this.props));
             }
         });
     };

--- a/src/contextmenu-layer.js
+++ b/src/contextmenu-layer.js
@@ -5,6 +5,7 @@ import invariant from "invariant";
 import _isObject from "lodash.isobject";
 
 import store from "./redux/store";
+import tagAttributes from "./tag-attributes.js";
 
 export default function(identifier, configure) {
     return function(Component) {
@@ -59,35 +60,13 @@ export default function(identifier, configure) {
                     }
                 });
             },
-            toAttributeArray: function(attributes){
-
-                var attributeArray = [];
-                for(var key in attributes){
-                    if(attributes.hasOwnProperty(key)){
-                        attributeArray[key] = attributes[key];
-                    }
-                }
-                return attributeArray;
-            },
-            getClassNames: function(attributes){
-
-                var classNames = "";
-                for(var key in attributes){
-                    if(attributes.hasOwnProperty(key)){
-                        if(key == "className"){
-                            classNames = classNames + " " + attributes[key];
-                        }
-                    }
-                }
-                return classNames;
-            },
             render: function() {
 
                 var attributes = this.props.attributes;
                 if(attributes == undefined) attributes = {};
 
-                var attributeArray = this.toAttributeArray(attributes);
-                var classNames = this.getClassNames(attributes);
+                var attributeArray = tagAttributes.toAttributeArray(attributes);
+                var classNames = tagAttributes.getClassNames(attributes);
 
                 //Make sure to add the react-context-menu-wrapper information
                 attributeArray["className"] = "react-context-menu-wrapper" + classNames;

--- a/src/contextmenu-layer.js
+++ b/src/contextmenu-layer.js
@@ -34,7 +34,8 @@ export default function(identifier, configure) {
             displayName: `${displayName}ContextMenuLayer`,
             getDefaultProps() {
                 return {
-                    renderTag: "div"
+                    renderTag: "div",
+                    attributes: {}
                 };
             },
             handleContextClick(event) {
@@ -62,11 +63,8 @@ export default function(identifier, configure) {
             },
             render: function() {
 
-                var attributes = this.props.attributes;
-                if(attributes == undefined) attributes = {};
-
-                var attributeArray = tagAttributes.toAttributeArray(attributes);
-                var classNames = tagAttributes.getClassNames(attributes);
+                var attributeArray = tagAttributes.toAttributeArray(this.props.attributes);
+                var classNames = tagAttributes.getClassNames(this.props.attributes);
 
                 //Make sure to add the react-context-menu-wrapper information
                 attributeArray["className"] = "react-context-menu-wrapper" + classNames;

--- a/src/menu-item.js
+++ b/src/menu-item.js
@@ -20,7 +20,8 @@ const MenuItem = React.createClass({
     getDefaultProps() {
         return {
             disabled: false,
-            data: {}
+            data: {},
+            attributes: {}
         };
     },
     handleClick(event) {
@@ -48,11 +49,7 @@ const MenuItem = React.createClass({
             disabled
         });
 
-        var attributes = this.props.attributes;
-        if(attributes == undefined) attributes = {};
-
-        var attributeArray = tagAttributes.toAttributeArray(attributes);
-        var menuItemClassNames = tagAttributes.getClassNames(attributes);
+        var menuItemClassNames = tagAttributes.getClassNames(this.props.attributes);
 
         //Make sure to add the react-context-menu-item information
         menuItemClassNames = "react-context-menu-item" + menuItemClassNames;

--- a/src/menu-item.js
+++ b/src/menu-item.js
@@ -5,6 +5,8 @@ import classnames from "classnames";
 import assign from "object-assign";
 import monitor from "./monitor";
 
+import tagAttributes from "./tag-attributes.js";
+
 let { PropTypes } = React;
 
 const MenuItem = React.createClass({
@@ -46,8 +48,17 @@ const MenuItem = React.createClass({
             disabled
         });
 
+        var attributes = this.props.attributes;
+        if(attributes == undefined) attributes = {};
+
+        var attributeArray = tagAttributes.toAttributeArray(attributes);
+        var menuItemClassNames = tagAttributes.getClassNames(attributes);
+
+        //Make sure to add the react-context-menu-item information
+        menuItemClassNames = "react-context-menu-item" + menuItemClassNames;
+
         return (
-            <div className="react-context-menu-item">
+            <div className={menuItemClassNames}>
                 <a href="#" className={classes} onClick={this.handleClick}>
                     {children}
                 </a>

--- a/src/tag-attributes.js
+++ b/src/tag-attributes.js
@@ -1,0 +1,23 @@
+module.exports.toAttributeArray = function(attributes){
+
+    var attributeArray = [];
+    for(var key in attributes){
+        if(attributes.hasOwnProperty(key)){
+            attributeArray[key] = attributes[key];
+        }
+    }
+    return attributeArray;
+};
+
+module.exports.getClassNames = function(attributes){
+
+    var classNames = "";
+    for(var key in attributes){
+        if(attributes.hasOwnProperty(key)){
+            if(key == "className"){
+                classNames = classNames + " " + attributes[key];
+            }
+        }
+    }
+    return classNames;
+};

--- a/src/tag-attributes.js
+++ b/src/tag-attributes.js
@@ -1,14 +1,3 @@
-module.exports.toAttributeArray = function(attributes){
-
-    var attributeArray = [];
-    for(var key in attributes){
-        if(attributes.hasOwnProperty(key)){
-            attributeArray[key] = attributes[key];
-        }
-    }
-    return attributeArray;
-};
-
 module.exports.getClassNames = function(attributes){
 
     var classNames = "";


### PR DESCRIPTION
These changes allow adding tag attributes to the contextmenu-layer by providing an optional "attributes" prop. For example, the object {colSpan: 1, className: "MyClassName"} would give the wrapper a colSpan tag of 1, and add the class "MyClassName" (keeping the "react-context-menu-wrapper" class). An example of this in use is below:

![contextmenu-wrapper](https://cloud.githubusercontent.com/assets/5407471/14939527/da2c98b0-0eff-11e6-82ba-3b0a6fc5e9c1.PNG)

These changes also allow adding multiple classes to the menu-item div by providing the optional "attributes" prop as before and providing each class required. For example, passing the object {className: "MyClassName1", className:"MyClassName2"} would put both classes on the menu-item div (keeping the "react-context-menu-item" class). An example of this in use is below:

![menuitemclassname](https://cloud.githubusercontent.com/assets/5407471/14939536/4d0223fa-0f00-11e6-95a5-d7d7db68af91.PNG)

I added a tag-attributes module to hold extra functions for tag grabbing and for retrieving the classes from the attribute object. Let me know if you have questions or comments on how I changed things! I would be happy to hear any feedback you have.