### PR TITLE
Clear submenu timers when submenu unmounts

### DIFF
--- a/src/submenu/index.js
+++ b/src/submenu/index.js
@@ -47,6 +47,11 @@ const SubMenu = React.createClass({
 
         this.closetimer = setTimeout(() => this.setState({visible: false}), this.props.hoverDelay);
     },
+    componentWillUnmount() {
+        if (this.opentimer) clearTimeout(this.opentimer);
+
+        if (this.closetimer) clearTimeout(this.closetimer);
+    },
     render() {
         let { disabled, children, title } = this.props,
             { visible } = this.state;


### PR DESCRIPTION
These need to be cleared because they call `setState` in their callbacks. You can see the error message by rapidly clicking out of an open submenu then checking the console. 

