### PR TITLE
Do not open menu on touchStart when holdToDisplay=0

### DIFF
--- a/src/contextmenu-layer.js
+++ b/src/contextmenu-layer.js
@@ -47,12 +47,14 @@ export default function(identifier, configure) {
                 }
             },
             handleTouchstart(event) {
-                event.persist();
+                if (this.props.holdToDisplay >= 0) {
+                    event.persist();
 
-                this.mouseDown = true;
-                setTimeout(() => {
-                    if (this.mouseDown) this.handleContextClick(event);
-                }, this.props.holdToDisplay);
+                    this.mouseDown = true;
+                    setTimeout(() => {
+                        if (this.mouseDown) this.handleContextClick(event);
+                    }, this.props.holdToDisplay);
+                }
             },
             handleTouchEnd(event) {
                 event.preventDefault();


### PR DESCRIPTION
On touch devices, when holdToDisplay is not set, context menu is opened instantly when touchStart event is triggered. This commit disables context menu display on touchStart if holdToDisplay not set.