### PR TITLE
Different ContextMenu for children #23

### DIFF
--- a/src/contextmenu-layer.js
+++ b/src/contextmenu-layer.js
@@ -77,6 +77,7 @@ export default function(identifier, configure) {
                 );
 
                 event.preventDefault();
+                event.stopPropagation();
 
                 const xPos = event.clientX || (event.touches && event.touches[0].pageX),
                     yPos = event.clientY || (event.touches && event.touches[0].pageY);


### PR DESCRIPTION
Fixes issue #23

Event was bubbling up from child to the ancestor, causing the ancestral menu to display instead of the more relevant menu on the child.