### PR TITLE
Correct position of the menu when out of viewport

### DIFF
--- a/src/context-menu/wrapper.js
+++ b/src/context-menu/wrapper.js
@@ -64,6 +64,14 @@ let ContextMenuWrapper = React.createClass({
         if (x + rect.width > innerWidth) {
             menuStyles.left -= rect.width;
         }
+        
+        if (menuStyles.top < 0) {
+            menuStyles.top = (rect.height < innerHeight) ? (innerHeight - rect.height) / 2 : 0;
+        }
+
+        if (menuStyles.left < 0) {
+            menuStyles.left = (rect.width < innerWidth) ? (innerWidth - rect.width) / 2 : 0;
+        }
 
         return menuStyles;
     },


### PR DESCRIPTION
When a context menu is higher than the place above the coordinates you clicked it would go outside of the viewport at the top of the screen. This PR makes it so that it will appear central in on the screen in that case. If the menu is higher than the viewport it will stick to the top of the screen. Applied the same logic to the horizontal axis.