### PR TITLE
Fix bug for menu not showing when page is scrolled

### DIFF
--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -96,12 +96,11 @@ export default class ContextMenu extends Component {
     }
 
     getMenuPosition = (x, y) => {
-        const {scrollTop: scrollX, scrollLeft: scrollY} = document.documentElement;
         const { innerWidth, innerHeight } = window;
         const rect = this.menu.getBoundingClientRect();
         const menuStyles = {
-            top: y + scrollY,
-            left: x + scrollX
+            top: y,
+            left: x
         };
 
         if (y + rect.height > innerHeight) {


### PR DESCRIPTION
Hi :)

We noticed a bug that, when you scroll a page, the context menu appears far away from the pointer. This bug can be reproduced using the latest version of Firefox, using the examples page.

Apparently, the event position is more than enough to position the menu. If there's a reason to keep the addition of scrolling, please let me know. 

Cheers.