### PR TITLE
Make menu closable with escape key

### DIFF
--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -73,6 +73,7 @@ export default class ContextMenu extends Component {
         document.removeEventListener('ontouchstart', this.handleOutsideClick);
         document.removeEventListener('scroll', this.handleHide);
         document.removeEventListener('contextmenu', this.handleHide);
+        document.removeEventListener('keyup', this.handleEscape);
         window.removeEventListener('resize', this.handleHide);
     }
 

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -64,6 +64,7 @@ export default class ContextMenu extends Component {
         document.addEventListener('ontouchstart', this.handleOutsideClick);
         document.addEventListener('scroll', this.handleHide);
         document.addEventListener('contextmenu', this.handleHide);
+        document.addEventListener('keyup', this.handleEscape);
         window.addEventListener('resize', this.handleHide);
     }
 
@@ -89,6 +90,12 @@ export default class ContextMenu extends Component {
         this.unregisterHandlers();
         this.setState({isVisible: false});
         callIfExists(this.props.onHide, e);
+    }
+
+    handleEscape = (e) => {
+        if (e.key === 'Escape') {
+            if (!this.menu.contains(e.target)) hideMenu();
+        }
     }
 
     handleOutsideClick = (e) => {


### PR DESCRIPTION
## Status
Ready

## Description
Allows the context menu to be closed by pressing the escape key. I think this is expected behavior with a context menu and would be a good addition to the library.