### PR TITLE
Styling the item divider

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The styling can be apllied to using following classes.
 - `react-contextmenu-item` : applied to menu items.
 - `react-contextmenu-item--active` : applied to menu items and title in submenu when submenu is open.
 - `react-contextmenu-item--disabled` : applied to menu items and title in submenu when they are disabled.
+- `react-contextmenu-item--divider` : applied to menu items with the `divider` prop.
 - `react-contextmenu-wrapper` : applied to wrapper around elements in `ContextMenuTrigger`.
 - `react-contextmenu-submenu` : applied to items that are submenus.
 

--- a/examples/SimpleMenu.js
+++ b/examples/SimpleMenu.js
@@ -33,6 +33,8 @@ export default class SimpleMenu extends Component {
                 <ContextMenu id={MENU_TYPE}>
                     <MenuItem onClick={this.handleClick} data={{item: 'item 1'}}>Menu Item 1</MenuItem>
                     <MenuItem onClick={this.handleClick} data={{item: 'item 2'}}>Menu Item 2</MenuItem>
+                    <MenuItem divider />
+                    <MenuItem onClick={this.handleClick} data={{item: 'item 3'}}>Menu Item 3</MenuItem>
                 </ContextMenu>
             </div>
         );

--- a/examples/react-contextmenu.css
+++ b/examples/react-contextmenu.css
@@ -40,6 +40,17 @@
     text-decoration: none;
 }
 
+.react-contextmenu-item--divider {
+    margin-bottom: 3px;
+    padding: 2px 0;
+    border-bottom: 1px solid #CCC;
+    cursor: inherit;
+}
+.react-contextmenu-item--divider:hover {
+    background-color: transparent;
+    border-color: #CCC;
+}
+
 .react-contextmenu-item.react-contextmenu-submenu {
 	padding: 0;
 }

--- a/examples/react-contextmenu.css
+++ b/examples/react-contextmenu.css
@@ -43,12 +43,12 @@
 .react-contextmenu-item--divider {
     margin-bottom: 3px;
     padding: 2px 0;
-    border-bottom: 1px solid #CCC;
+    border-bottom: 1px solid rgba(0,0,0,.15);
     cursor: inherit;
 }
 .react-contextmenu-item--divider:hover {
     background-color: transparent;
-    border-color: #CCC;
+    border-color: rgba(0,0,0,.15);
 }
 
 .react-contextmenu-item.react-contextmenu-submenu {

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -38,9 +38,10 @@ export default class MenuItem extends Component {
     }
 
     render() {
-        const { disabled, children, attributes } = this.props;
+        const { disabled, divider, children, attributes } = this.props;
         const menuItemClassNames = cx(cssClasses.menuItem, attributes && attributes.className, {
-            [cssClasses.menuItemDisabled]: disabled
+            [cssClasses.menuItemDisabled]: disabled,
+            [cssClasses.menuItemDivider]: divider
         });
 
         return (

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,6 +17,7 @@ export const cssClasses = {
     menuItem: 'react-contextmenu-item',
     menuItemActive: 'react-contextmenu-item--active',
     menuItemDisabled: 'react-contextmenu-item--disabled',
+    menuItemDivider: 'react-contextmenu-item--divider',
     subMenu: 'react-contextmenu-submenu'
 };
 


### PR DESCRIPTION
Hi

Thought it was weird that the `divider` prop you show in the first example on the README didn't do anything. So this change adds a `react-contextmenu-item--divider` class to any `MenuItem`s with a `divider` prop and adds example CSS style to `react-contextmenu.css`.

Without styles currently:
![](http://i.imgur.com/aOREO7S.gif)

With new prop logic and styles:
![](http://i.imgur.com/We8N1MS.gif)

^ I added a third item to the SimpleMenu example to show this feature, and kept it in the PR - hope that's alright.