### PR TITLE
Accept functions as a valid prop type in `renderTag`

### DIFF
--- a/src/ContextMenuTrigger.js
+++ b/src/ContextMenuTrigger.js
@@ -12,7 +12,10 @@ export default class ContextMenuTrigger extends Component {
         collect: PropTypes.func,
         disable: PropTypes.bool,
         holdToDisplay: PropTypes.number,
-        renderTag: PropTypes.node
+        renderTag: PropTypes.oneOfType([
+            PropTypes.node,
+            PropTypes.func
+        ])
     };
 
     static defaultProps = {


### PR DESCRIPTION
The current prop types validation will warn when a valid React class or stateless component is used as `renderTag`

The below example will not throw a warning anymore:

```js
const Row = ({ children }) => <tr className="fancy tr">{children}</tr>;

<ContextMenuTrigger 
    renderTag={Row} 
    name={item.name}
    id={MENU_TYPE} holdToDisplay={1000} key={i}
    collect={collect}>
    <td>{item.name}</td>
</ContextMenuTrigger>
```