### PR TITLE
Allow working on browsers without requestAnimationFrame

### DIFF
--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -43,12 +43,14 @@ export default class ContextMenu extends Component {
 
     componentDidUpdate() {
         if (this.state.isVisible) {
-            window.requestAnimationFrame(() => {
+            const wrapper = window.requestAnimationFrame || setTimeout;
+
+            wrapper(() => {
                 const { x, y } = this.state;
 
                 const { top, left } = this.getMenuPosition(x, y);
 
-                window.requestAnimationFrame(() => {
+                wrapper(() => {
                     this.menu.style.top = `${top}px`;
                     this.menu.style.left = `${left}px`;
                     this.menu.style.opacity = 1;


### PR DESCRIPTION
Would be nice to possibly support IE9+. I understand you can't guarantee support, but if you accept patches I'll try and make it work.