### PR TITLE
[Improvement] Got rid of React 15.5.x deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "homepage": "https://github.com/vkbansal/react-contextmenu",
   "dependencies": {
     "classnames": "^2.2.5",
-    "object-assign": "^4.1.0"
+    "object-assign": "^4.1.0",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
@@ -72,10 +73,10 @@
     "http-server": "^0.9.0",
     "jest": "^19.0.2",
     "jsdom": "^9.12.0",
-    "react": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "react-router-dom": "^4.0.0",
+    "react": "^15.5.4",
+    "react-addons-test-utils": "^15.5.1",
+    "react-dom": "^15.5.4",
+    "react-router-dom": "^4.1.1",
     "rimraf": "^2.6.1",
     "webpack": "^2.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
   "homepage": "https://github.com/vkbansal/react-contextmenu",
   "dependencies": {
     "classnames": "^2.2.5",
-    "object-assign": "^4.1.0",
-    "prop-types": "^15.5.8"
+    "object-assign": "^4.1.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react-dom": "^0.14.0 || ^15.0.0",
+    "prop-types": "^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
@@ -77,6 +77,7 @@
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",
     "react-router-dom": "^4.1.1",
+    "prop-types": "^15.5.8",
     "rimraf": "^2.6.1",
     "webpack": "^2.3.2"
   },

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import assign from 'object-assign';
 

--- a/src/ContextMenuTrigger.js
+++ b/src/ContextMenuTrigger.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import assign from 'object-assign';
 

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import assign from 'object-assign';
 

--- a/src/SubMenu.js
+++ b/src/SubMenu.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import { cssClasses, hasOwnProp } from './helpers';


### PR DESCRIPTION
[Latest version of React](https://github.com/facebook/react/releases/tag/v15.5.0) added a deprecation warning to React.PropTypes and React.createClass.
This pull request adds the new [npm package prop-types](https://www.npmjs.com/package/prop-types).