### PR TITLE
Wrapping MenuItem or SubMenu wasn't possible anymore

### DIFF
--- a/src/AbstractMenu.js
+++ b/src/AbstractMenu.js
@@ -65,7 +65,7 @@ export default class AbstractMenu extends Component {
         const childCollector = (child) => {
             if ([MenuItem, this.getSubMenuType()].indexOf(child.type) < 0) {
                 // Maybe the MenuItem or SubMenu is capsuled in a wrapper div or something else
-                childCollector(child.props.children);
+                React.Children.forEach(child.props.children, childCollector);
             } else if (!child.props.divider) {
                 children.push(child);
             }


### PR DESCRIPTION
Sorry for all the PRs 😄 
With my previous added implementation it wasn't possible anymore to wrap e.g. the `MenuItem` in an custom component like this:
```
export default MyCoolCustomMenuItemAction = () => (
  <MenuItem onClick={e => alert('fancy stuff')}>
    <CoolCustomIcon /><span>Menu Entry</span>
  </MenuItem>
)
```

```
<ContextMenu>
  <MyCoolCustomMenuItemAction />
</ContextMenu>
```

Now I implemented a simple recursive way to render and select the MenuItems/SubMenus.