### PR TITLE
SubMenu opacity transition no longer flicker

### DIFF
--- a/examples/react-contextmenu.css
+++ b/examples/react-contextmenu.css
@@ -12,6 +12,7 @@
     outline: none;
     opacity: 0;
     pointer-events: none;
+    transition: opacity 250ms ease !important;
 }
 
 .react-contextmenu.react-contextmenu--visible {

--- a/src/SubMenu.js
+++ b/src/SubMenu.js
@@ -78,13 +78,15 @@ export default class SubMenu extends AbstractMenu {
                 this.setState({ selectedItem: null });
             });
         } else {
-            this.subMenu.addEventListener('transitionend', () => {
+            const cleanup = () => {
+                this.subMenu.removeEventListener('transitionend', cleanup);
                 this.subMenu.style.removeProperty('bottom');
                 this.subMenu.style.removeProperty('right');
                 this.subMenu.style.top = 0;
                 this.subMenu.style.left = '100%';
                 this.unregisterHandlers();
-            }, { once: true });
+            };
+            this.subMenu.addEventListener('transitionend', cleanup);
             this.subMenu.classList.remove(cssClasses.menuVisible);
         }
     }

--- a/src/SubMenu.js
+++ b/src/SubMenu.js
@@ -78,12 +78,14 @@ export default class SubMenu extends AbstractMenu {
                 this.setState({ selectedItem: null });
             });
         } else {
+            this.subMenu.addEventListener('transitionend', () => {
+                this.subMenu.style.removeProperty('bottom');
+                this.subMenu.style.removeProperty('right');
+                this.subMenu.style.top = 0;
+                this.subMenu.style.left = '100%';
+                this.unregisterHandlers();
+            }, { once: true });
             this.subMenu.classList.remove(cssClasses.menuVisible);
-            this.subMenu.style.removeProperty('bottom');
-            this.subMenu.style.removeProperty('right');
-            this.subMenu.style.top = 0;
-            this.subMenu.style.left = '100%';
-            this.unregisterHandlers();
         }
     }
 
@@ -212,6 +214,7 @@ export default class SubMenu extends AbstractMenu {
             ref: this.subMenuRef,
             style: {
                 position: 'absolute',
+                transition: 'opacity 1ms', // trigger transitionend event
                 top: 0,
                 left: '100%'
             },


### PR DESCRIPTION
* If you used the SubMenu with an css transition of opacity, the SubMenu had possible rearranged during fade out.
* Now every SubMenu have a default transition of 1ms, so that the transitionend will always trigger
* You can override the transition-duration with css