### PR TITLE
if `props.collect` returns Promise, resolve it before `showMenu`

### DIFF
--- a/src/ContextMenuTrigger.js
+++ b/src/ContextMenuTrigger.js
@@ -97,12 +97,22 @@ export default class ContextMenuTrigger extends Component {
 
         hideMenu();
 
-        showMenu({
+        let data = callIfExists(this.props.collect, this.props);
+        let showMenuConfig = {
             position: { x, y },
             target: this.elem,
             id: this.props.id,
-            data: callIfExists(this.props.collect, this.props)
-        });
+            data
+        };
+        if (data && (typeof data.then === 'function')) {
+            // it's promise
+            data.then((resp) => {
+                showMenuConfig.data = resp;
+                showMenu(showMenuConfig);
+            });
+        } else {
+            showMenu(showMenuConfig);
+        }
     }
 
     elemRef = (c) => {


### PR DESCRIPTION
the collect may need talk to back end server to fetch some data for contextmenu.

If `props.collect` is a Promise, resolve it before calling `showMenu`