### PR TITLE
Fix keyboard handling issues

### DIFF
--- a/src/AbstractMenu.js
+++ b/src/AbstractMenu.js
@@ -19,6 +19,10 @@ export default class AbstractMenu extends Component {
     }
 
     handleKeyNavigation = (e) => {
+        if (!this.state.isVisible) {
+            return;
+        }
+        
         switch (e.keyCode) {
             case 37: // left arrow
             case 27: // escape
@@ -63,6 +67,11 @@ export default class AbstractMenu extends Component {
         const { selectedItem } = this.state;
         const children = [];
         const childCollector = (child) => {
+            // child can be empty in case you do conditional rendering of components, in which case it should not be accounted for as a real child
+            if (child === null || child === false || child === undefined || child === '') {
+                return;
+            }
+            
             if ([MenuItem, this.getSubMenuType()].indexOf(child.type) < 0) {
                 // Maybe the MenuItem or SubMenu is capsuled in a wrapper div or something else
                 React.Children.forEach(child.props.children, childCollector);

--- a/src/AbstractMenu.js
+++ b/src/AbstractMenu.js
@@ -22,7 +22,7 @@ export default class AbstractMenu extends Component {
         if (!this.state.isVisible) {
             return;
         }
-        
+
         switch (e.keyCode) {
             case 37: // left arrow
             case 27: // escape
@@ -67,12 +67,12 @@ export default class AbstractMenu extends Component {
         const { selectedItem } = this.state;
         const children = [];
         const childCollector = (child) => {
-            // child can be empty in case you do conditional rendering of components, in which 
+            // child can be empty in case you do conditional rendering of components, in which
             // case it should not be accounted for as a real child
             if (!child) {
                 return;
             }
-            
+
             if ([MenuItem, this.getSubMenuType()].indexOf(child.type) < 0) {
                 // Maybe the MenuItem or SubMenu is capsuled in a wrapper div or something else
                 React.Children.forEach(child.props.children, childCollector);

--- a/src/AbstractMenu.js
+++ b/src/AbstractMenu.js
@@ -67,8 +67,9 @@ export default class AbstractMenu extends Component {
         const { selectedItem } = this.state;
         const children = [];
         const childCollector = (child) => {
-            // child can be empty in case you do conditional rendering of components, in which case it should not be accounted for as a real child
-            if (child === null || child === false || child === undefined || child === '') {
+            // child can be empty in case you do conditional rendering of components, in which 
+            // case it should not be accounted for as a real child
+            if (!child) {
                 return;
             }
             


### PR DESCRIPTION
- Prevent keyboard events from being handled all the time even when the menu is closed
- Prevent errors showing up when you do conditional display of components inside a menu, something like `{someFlag && <SubMenu .../>`

/cc @codeart1st