### PR TITLE
export show/hideMenu methods in order to customize the trigger

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,4 @@ export { default as ContextMenuTrigger } from './ContextMenuTrigger';
 export { default as MenuItem } from './MenuItem';
 export { default as SubMenu } from './SubMenu';
 export { default as connectMenu } from './connectMenu';
-export { hideMenu, showMenu  } from './actions';
+export { hideMenu, showMenu } from './actions';

--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,5 @@ export { default as ContextMenuTrigger } from './ContextMenuTrigger';
 export { default as MenuItem } from './MenuItem';
 export { default as SubMenu } from './SubMenu';
 export { default as connectMenu } from './connectMenu';
+export { hideMenu as hideMenu } from './actions';
+export { showMenu as showMenu } from './actions'; 

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,4 @@ export { default as ContextMenuTrigger } from './ContextMenuTrigger';
 export { default as MenuItem } from './MenuItem';
 export { default as SubMenu } from './SubMenu';
 export { default as connectMenu } from './connectMenu';
-export { hideMenu as hideMenu } from './actions';
-export { showMenu as showMenu } from './actions'; 
+export { hideMenu, showMenu  } from './actions';


### PR DESCRIPTION
I encounter a problem on triggering the context menu from an element that is not a view itself so it cannot be the child of ContextMenuTrigger. In the JointJS framework, the cell elements are part of paper view, so in order to trigger the contextmenu on the cell elements i need to use the hideMenu and showMenu methods in the cell contexmenu event. Exposing these methods will make the triggering more customized and easier to adapt. 