### PR TITLE
Preventing propagation with nested menus involving draggable elements...

### DIFF
--- a/src/ContextMenuTrigger.js
+++ b/src/ContextMenuTrigger.js
@@ -33,6 +33,7 @@ export default class ContextMenuTrigger extends Component {
     handleMouseDown = (event) => {
         if (this.props.holdToDisplay >= 0 && event.button === 0) {
             event.persist();
+            event.stopPropagation();
 
             this.mouseDownTimeoutId = setTimeout(
                 () => this.handleContextClick(event),
@@ -61,6 +62,7 @@ export default class ContextMenuTrigger extends Component {
 
         if (this.props.holdToDisplay >= 0) {
             event.persist();
+            event.stopPropagation();
 
             this.touchstartTimeoutId = setTimeout(
                 () => {


### PR DESCRIPTION
Hello vkbansal!

Before explaining this, I just want to say thank you for building this awesome project! It has helped immensely with my current work. I was able to use this seamlessly with 'react-dnd'. I am not permitted to share the source of what I have been working on that helped me discover the following issue.

I have been working on a project (react v15.6.1) where I have draggable elements/boxes upon droppable grid cells where both the grid cells and the draggable elements have context menus attached. Everything worked perfectly, except for when I am using the holdToDisplay (this is happening both on mobile and desktop). For some reason, on desktop and mobile devices (like the iPad), whenever I click/touch & hold on one of the elements/boxes (on top of the grid cell), it will open up the menu of the grid cell instead of the menu of the nested element. In other words, the event propagates to the parent, which is what I don't want. 

I understand that the nested menu example on your demo page is working. But in my case, using react-dnd and their html5/touch backends, it is not. 

While I unfortunately do not have an example fiddle to show (since I don't have the time at the moment), I do have this pull request, adding 2 simple lines which I have confirmed (on both desktop and mobile) fixes my issue.

All tests passed. Let me know what you think...

Thanks,
AJ