### PR TITLE
Added onShow function for ContextMenuTrigger

### DIFF
--- a/src/ContextMenuTrigger.js
+++ b/src/ContextMenuTrigger.js
@@ -17,7 +17,8 @@ export default class ContextMenuTrigger extends Component {
         renderTag: PropTypes.oneOfType([
             PropTypes.node,
             PropTypes.func
-        ])
+        ]),
+        onShow: PropTypes.func
     };
 
     static defaultProps = {
@@ -25,7 +26,8 @@ export default class ContextMenuTrigger extends Component {
         collect() { return null; },
         disable: false,
         holdToDisplay: 1000,
-        renderTag: 'div'
+        renderTag: 'div',
+        onShow() { return null; }
     };
 
     touchHandled = false;
@@ -111,9 +113,17 @@ export default class ContextMenuTrigger extends Component {
             data.then((resp) => {
                 showMenuConfig.data = resp;
                 showMenu(showMenuConfig);
+                callIfExists(
+                    this.props.onShow,
+                    showMenuConfig
+                );
             });
         } else {
             showMenu(showMenuConfig);
+            callIfExists(
+                this.props.onShow,
+                showMenuConfig
+            );
         }
     }
 


### PR DESCRIPTION
Sometimes it is needed to know for what entity we need to show the options. Each entity might have different set of options. Using this function we don't need to create multiple `ContextMenu`. Instead a single `ContextMenu` can be used but different `MenuItem` based on the `props` that `onShow` function of `ContextMenuTrigger` will receive. 