### PR TITLE
Add inline styles as a prop and updated the snapshot

### DIFF
--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -185,7 +185,7 @@ export default class ContextMenu extends AbstractMenu {
     render() {
         const { children, className, style } = this.props;
         const { isVisible } = this.state;
-        const inlineStyle = Object.assign(
+        const inlineStyle = assign(
           {},
           style,
           { position: 'fixed', opacity: 0, pointerEvents: 'none' }

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -18,7 +18,8 @@ export default class ContextMenu extends AbstractMenu {
         hideOnLeave: PropTypes.bool,
         onHide: PropTypes.func,
         onMouseLeave: PropTypes.func,
-        onShow: PropTypes.func
+        onShow: PropTypes.func,
+        style: PropTypes.object
     };
 
     static defaultProps = {
@@ -27,7 +28,8 @@ export default class ContextMenu extends AbstractMenu {
         hideOnLeave: false,
         onHide() { return null; },
         onMouseLeave() { return null; },
-        onShow() { return null; }
+        onShow() { return null; },
+        style: {}
     };
 
     constructor(props) {
@@ -181,16 +183,20 @@ export default class ContextMenu extends AbstractMenu {
     }
 
     render() {
-        const { children, className } = this.props;
+        const { children, className, style } = this.props;
         const { isVisible } = this.state;
-        const style = { position: 'fixed', opacity: 0, pointerEvents: 'none' };
+        const inlineStyle = Object.assign(
+          {},
+          style,
+          { position: 'fixed', opacity: 0, pointerEvents: 'none' }
+        );
         const menuClassnames = cx(cssClasses.menu, className, {
             [cssClasses.menuVisible]: isVisible
         });
 
         return (
             <nav
-                role='menu' tabIndex='-1' ref={this.menuRef} style={style} className={menuClassnames}
+                role='menu' tabIndex='-1' ref={this.menuRef} style={inlineStyle} className={menuClassnames}
                 onContextMenu={this.handleContextMenu} onMouseLeave={this.handleMouseLeave}>
                 {this.renderChildren(children)}
             </nav>

--- a/tests/__snapshots__/ContextMenu.test.js.snap
+++ b/tests/__snapshots__/ContextMenu.test.js.snap
@@ -9,6 +9,7 @@ exports[`ContextMenu tests does not shows when event with incorrect "id" is trig
   onHide={[Function]}
   onMouseLeave={[Function]}
   onShow={[Function]}
+  style={Object {}}
 >
   <nav
     className="react-contextmenu"
@@ -36,6 +37,7 @@ exports[`ContextMenu tests does not shows when event with incorrect "id" is trig
   onHide={[Function]}
   onMouseLeave={[Function]}
   onShow={[Function]}
+  style={Object {}}
 >
   <nav
     className="react-contextmenu"
@@ -63,6 +65,7 @@ exports[`ContextMenu tests shows when event with correct "id" is triggered 1`] =
   onHide={[Function]}
   onMouseLeave={[Function]}
   onShow={[Function]}
+  style={Object {}}
 >
   <nav
     className="react-contextmenu"
@@ -90,6 +93,7 @@ exports[`ContextMenu tests shows when event with correct "id" is triggered 2`] =
   onHide={[Function]}
   onMouseLeave={[Function]}
   onShow={[Function]}
+  style={Object {}}
 >
   <nav
     className="react-contextmenu react-contextmenu--visible"


### PR DESCRIPTION
I was facing issues with styling the `nav` attribute. I wasn't able to use classNames for styling because of other restrictions and there was no other way. This is an optional prop and doesn't provide any harm.