### PR TITLE
fix issue 168: Menu doesn't close when press 'Enter'

### DIFF
--- a/src/AbstractMenu.js
+++ b/src/AbstractMenu.js
@@ -45,8 +45,12 @@ export default class AbstractMenu extends Component {
             case 13: // enter
                 e.preventDefault();
                 this.tryToOpenSubMenu(e);
-                if (this.seletedItemRef && this.seletedItemRef.ref instanceof HTMLElement) {
+                if (this.seletedItemRef &&
+                    this.seletedItemRef.ref instanceof HTMLElement &&
+                    !this.seletedItemRef.ref.props.disabled) {
                     this.seletedItemRef.ref.click();
+                } else {
+                    this.hideMenu(e);
                 }
                 break;
             default:

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -143,7 +143,7 @@ export default class ContextMenu extends AbstractMenu {
     }
 
     hideMenu = (e) => {
-        if (e.keyCode === 27) { // enter
+        if (e.keyCode === 27 || e.keyCode === 13) { // ECS or enter
             hideMenu();
         }
     }

--- a/tests/ContextMenu.test.js
+++ b/tests/ContextMenu.test.js
@@ -115,6 +115,30 @@ describe('ContextMenu tests', () => {
         component.unmount();
     });
 
+    test('menu should close on "Enter" when selectedItem is null', () => {
+        const data = { position: { x: 50, y: 50 }, id: 'CORRECT_ID' };
+        const onHide = jest.fn();
+        const component = mount(<ContextMenu id={data.id} onHide={onHide} />);
+        const enter = new window.KeyboardEvent('keydown', { keyCode: 13 });
+
+        showMenu(data);
+        expect(component.state()).toEqual(
+            Object.assign(
+                { isVisible: true, forceSubMenuOpen: false, selectedItem: null },
+                data.position
+            )
+        );
+        document.dispatchEvent(enter);
+        expect(component.state()).toEqual(
+            Object.assign(
+                { isVisible: false, forceSubMenuOpen: false, selectedItem: null },
+                data.position
+            )
+        );
+        expect(onHide).toHaveBeenCalled();
+        component.unmount();
+    });
+
     test('menu should close on "outside" click', () => {
         const data = { position: { x: 50, y: 50 }, id: 'CORRECT_ID' };
         const onHide = jest.fn();


### PR DESCRIPTION
There are two cases:
1. Given the menu is open and the selected item is disabled, When I press Enter, the menu doesn't close, the expected behavior is that the menu should close
2. Given the menu is open and no item is selected, When I press Enter, the menu doesn't close, the expected behavior is that the menu should close