### PR TITLE
Fix submenu closing whenever an unrelated contextmenu is being hidden

### DIFF
--- a/src/SubMenu.js
+++ b/src/SubMenu.js
@@ -151,7 +151,12 @@ export default class SubMenu extends AbstractMenu {
         return position;
     }
 
-    hideMenu = () => {
+    hideMenu = (e) => {
+        // avoid closing submenus of a different menu tree
+        if (e.detail && e.detail.id && this.menu && e.detail.id !== this.menu.id) {
+            return;
+        }
+
         if (this.props.forceOpen) {
             this.props.forceClose();
         }


### PR DESCRIPTION
Regression introduced by https://github.com/vkbansal/react-contextmenu/pull/145 - as we use multiple submenu instances we really need to avoid having hideMenu hide all of them, ids must be checked always like in https://github.com/vkbansal/react-contextmenu/blob/6a4330554630689724be4feb7eece119896d67d9/src/ContextMenu.js#L114