### PR TITLE
Fixed clicking on items in a submenu not removing event listeners

### DIFF
--- a/src/SubMenu.js
+++ b/src/SubMenu.js
@@ -108,7 +108,7 @@ export default class SubMenu extends AbstractMenu {
 
         if (this.closetimer) clearTimeout(this.closetimer);
 
-        this.unregisterHandlers();
+        this.unregisterHandlers(true);
     }
 
     getMenuPosition = () => {
@@ -212,9 +212,11 @@ export default class SubMenu extends AbstractMenu {
         document.addEventListener('keydown', this.handleKeyNavigation);
     }
 
-    unregisterHandlers = () => {
+    unregisterHandlers = (dismounting) => {
         document.removeEventListener('keydown', this.handleKeyNavigation);
-        document.addEventListener('keydown', this.props.parentKeyNavigationHandler);
+        if (!dismounting) {
+            document.addEventListener('keydown', this.props.parentKeyNavigationHandler);
+        }
     }
 
     render() {


### PR DESCRIPTION
When you click on a MenuItem inside of a SubMenu, it'll hide the submenu and unregister its listeners and re-registers its parents. Then the ContextMenu will hide and unregister its listeners. That leaves no listeners still registered. 

However, then the ContextMenu dismounts, and that causes the SubMenu to dismount as well. Specifically, SubMenu will dismount after ContextMenu. So ContextMenu dismounts and unregisters its listeners, and then SubMenu dismounts and unregisters its listeners and re-registers its parents. You'll notice that leaves the parent's listeners registered, preventing things like escape or enter from working anymore. 

To fix this problem I added a flag to SubMenu's `unregisterHandlers` function that will prevent it from re-registering its parents' listeners. 

Unfortunately, I do not have enough knowledge with Jasmine to write the test for this bug fix, but what would need to happen is create a SubMenu with a MenuItem in it, simulate clicking on the MenuItem, then ensure there are no lingering event listeners. 