### PR TITLE
Add event handler for clicking outside of Context Menu

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,14 +12,15 @@ Base Contextmenu Component.
 
 #### PropTypes
 
-| Property     | Type     | Required? | Description                                                      |
-|--------------|----------|-----------|------------------------------------------------------------------|
-| id           | String   | ✓         | A unique identifier for a menu.                                  |
-| hideOnLeave  | Boolean  |           | Hides the context menu on mouse leave.                           |
-| onMouseLeave | Function |           | Callback called when the mouse leaves the menu or submenu areas. |
-| onHide       | Function |           | Callback called when the menu is hidden.                         |
-| onShow       | Function |           | Callback called when the menu is shown.                          |
-| className    | String   |           | Custom `className` applied to root element of the context-menu.  |
+| Property       | Type     | Required? | Description                                                              |
+|----------------|----------|-----------|--------------------------------------------------------------------------|
+| id             | String   | ✓         | A unique identifier for a menu.                                          |
+| hideOnLeave    | Boolean  |           | Hides the context menu on mouse leave.                                   |
+| onMouseLeave   | Function |           | Callback called when the mouse leaves the menu or submenu areas.         |
+| onHide         | Function |           | Callback called when the menu is hidden.                                 |
+| onOutsideClick | Function |           | Callback called when the mouse clicked outside of menu or submenu areas. |
+| onShow         | Function |           | Callback called when the menu is shown.                                  |
+| className      | String   |           | Custom `className` applied to root element of the context-menu.          |
 
 ### `<ContextMenuTrigger />`
 

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -121,8 +121,10 @@ export default class ContextMenu extends AbstractMenu {
     }
 
     handleOutsideClick = (e) => {
-        if (!this.menu.contains(e.target)) hideMenu();
-        callIfExists(this.props.onOutsideClick, e);
+        if (!this.menu.contains(e.target)) {
+            hideMenu();
+            callIfExists(this.props.onOutsideClick, e);
+        }
     }
 
     handleMouseLeave = (event) => {

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -18,6 +18,7 @@ export default class ContextMenu extends AbstractMenu {
         hideOnLeave: PropTypes.bool,
         onHide: PropTypes.func,
         onMouseLeave: PropTypes.func,
+        onOutsideClick: PropTypes.func,
         onShow: PropTypes.func,
         style: PropTypes.object
     };
@@ -28,6 +29,7 @@ export default class ContextMenu extends AbstractMenu {
         hideOnLeave: false,
         onHide() { return null; },
         onMouseLeave() { return null; },
+        onOutsideClick() { return null; },
         onShow() { return null; },
         style: {}
     };
@@ -120,6 +122,7 @@ export default class ContextMenu extends AbstractMenu {
 
     handleOutsideClick = (e) => {
         if (!this.menu.contains(e.target)) hideMenu();
+        callIfExists(this.props.onOutsideClick, e);
     }
 
     handleMouseLeave = (event) => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ declare module "react-contextmenu" {
         hideOnLeave?: boolean,
         onHide?: {(event: any): void},
         onMouseLeave?: {(event: React.MouseEvent<HTMLElement>, data: Object, target: HTMLElement): void} | Function,
+        onOutsideClick?: {(event: any): void},
         onShow?: {(event: any): void},
     }
 

--- a/tests/ContextMenu.test.js
+++ b/tests/ContextMenu.test.js
@@ -139,10 +139,11 @@ describe('ContextMenu tests', () => {
         component.unmount();
     });
 
-    test('menu should close on "outside" click', () => {
+    test('menu should close on "outside" click and onOutsideClick is triggered correctly', () => {
         const data = { position: { x: 50, y: 50 }, id: 'CORRECT_ID' };
         const onHide = jest.fn();
-        const component = mount(<ContextMenu id={data.id} onHide={onHide} />);
+        const onOutsideClick = jest.fn();
+        const component = mount(<ContextMenu id={data.id} onHide={onHide} onOutsideClick={onOutsideClick} />);
         const outsideClick = new window.MouseEvent('mousedown', { target: document });
 
         showMenu(data);
@@ -167,6 +168,7 @@ describe('ContextMenu tests', () => {
             )
         );
         expect(onHide).toHaveBeenCalled();
+        expect(onOutsideClick).toHaveBeenCalled();
         component.unmount();
     });
 

--- a/tests/__snapshots__/ContextMenu.test.js.snap
+++ b/tests/__snapshots__/ContextMenu.test.js.snap
@@ -8,6 +8,7 @@ exports[`ContextMenu tests does not shows when event with incorrect "id" is trig
   id="CORRECT_ID"
   onHide={[Function]}
   onMouseLeave={[Function]}
+  onOutsideClick={[Function]}
   onShow={[Function]}
   style={Object {}}
 >
@@ -36,6 +37,7 @@ exports[`ContextMenu tests does not shows when event with incorrect "id" is trig
   id="CORRECT_ID"
   onHide={[Function]}
   onMouseLeave={[Function]}
+  onOutsideClick={[Function]}
   onShow={[Function]}
   style={Object {}}
 >
@@ -64,6 +66,7 @@ exports[`ContextMenu tests shows when event with correct "id" is triggered 1`] =
   id="CORRECT_ID"
   onHide={[Function]}
   onMouseLeave={[Function]}
+  onOutsideClick={[Function]}
   onShow={[Function]}
   style={Object {}}
 >
@@ -92,6 +95,7 @@ exports[`ContextMenu tests shows when event with correct "id" is triggered 2`] =
   id="CORRECT_ID"
   onHide={[Function]}
   onMouseLeave={[Function]}
+  onOutsideClick={[Function]}
   onShow={[Function]}
   style={Object {}}
 >


### PR DESCRIPTION
Similar to onShow and onHide callback methods, onOutsideClick allows the program to perform additional actions when the user opens a context menu and clicks outside of the context menu items.

`<ContextMenu id="ShowContextMenu_ContextMenuId" className="topmost" onShow={this.onShowContextMenu} onHide={this.onHideContextMenu} onOutsideClick={this.onOutsideClickContextMenu}>
   ...
</ContextMenu>`