### PR TITLE
Allow access to originating event target

### DIFF
--- a/src/ContextMenuTrigger.js
+++ b/src/ContextMenuTrigger.js
@@ -114,16 +114,20 @@ export default class ContextMenuTrigger extends Component {
         let showMenuConfig = {
             position: { x, y },
             target: this.elem,
-            id: this.props.id,
-            data
+            id: this.props.id
         };
         if (data && (typeof data.then === 'function')) {
             // it's promise
             data.then((resp) => {
-                showMenuConfig.data = resp;
+                showMenuConfig.data = assign({}, resp, {
+                    target: event.target
+                });
                 showMenu(showMenuConfig);
             });
         } else {
+            showMenuConfig.data = assign({}, data, {
+                target: event.target
+            });
             showMenu(showMenuConfig);
         }
     }


### PR DESCRIPTION
Passing event target into `trigger` prop alongside user collected data. This will allow the package user to have access to the event target in the spawned `ContextMenu`. Helpful in the case where you would like to do event delegation, etc.

See also: #191 

My current thinking was to pass it embedded into `data` as it seems to be inherently related to the `trigger`. More than happy to change that though and have it passed along as another property. One reason I can think of going in that direction would be potential name conflicts (i.e. - the user has a `collect` with a prop `target`). 