### PR TITLE
Fix opening links on Firefox

### DIFF
--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -34,7 +34,9 @@ export default class MenuItem extends Component {
     };
 
     handleClick = (event) => {
-        event.preventDefault();
+        if (event.button !== 0 && event.button !== 1) {
+            event.preventDefault();
+        }
 
         if (this.props.disabled || this.props.divider) return;
 


### PR DESCRIPTION
This fixes an annoying issue when using Firefox (Chrome is not affected) where if I have an `<a>` inside of a `<MenuItem>` then middle clicking that link doesn't do anything. (~~Left clicking still works.~~ Actually it doesn't.)