### PR TITLE
enhanced submenu typescript definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,7 +31,7 @@ declare module "react-contextmenu" {
     }
 
     interface SubMenuProps {
-        title: React.ReactElement<any>,
+        title: React.ReactElement<any> | React.ReactText,
         className?: string,
         disabled?: boolean,
         hoverDelay?: number,


### PR DESCRIPTION
Putting string into Submenu's title comes with  type error.

![react-contextmenu_submenu_title_type_error](https://user-images.githubusercontent.com/18019463/54730913-6fa1e700-4bc6-11e9-9095-f6a50a6064a6.png)
