### PR TITLE
Support for menus contained in a shadow DOM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8484,9 +8484,9 @@
       "dev": true
     },
     "react-router": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.4.0.tgz",
-      "integrity": "sha512-qTGsOSF2b02zOsUfcnHjw7muI0Ejx+yA2e4P9qqzB2O+N3Icpca4epViXRgkBIvBjagXBtroxXqH0RJhYDMUbg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.0.tgz",
+      "integrity": "sha512-6EQDakGdLG/it2x9EaCt9ZpEEPxnd0OCLBHQ1AcITAAx7nCnyvnzf76jKWG1s2/oJ7SSviUgfWHofdYljFexsA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2",
@@ -8502,16 +8502,16 @@
       }
     },
     "react-router-dom": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.4.0.tgz",
-      "integrity": "sha512-r4knbi8lanTGrwoUXFaWALrJZOAl3h9bdFUz4woHgEm7/bYcpBGfnYhPU82xjXrPeJyWF6OmIxpwXjxos30gOQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.0.tgz",
+      "integrity": "sha512-wSpja5g9kh5dIteZT3tUoggjnsa+TPFHSMrpHXMpFsaHhQkm/JNVGh2jiF9Dkh4+duj4MKCkwO6H08u6inZYgQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "history": "^4.8.0-beta.0",
+        "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "^4.4.0",
+        "react-router": "5.0.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "prop-types": "~15.7.2",
     "react": "~16.8.4",
     "react-dom": "~16.8.4",
-    "react-router-dom": "~4.4.0",
+    "react-router-dom": "^5.0.0",
     "react-test-renderer": "~16.8.4",
     "rimraf": "~2.6.3",
     "style-loader": "~0.19.0",

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -7,7 +7,7 @@ import listener from './globalEventListener';
 import AbstractMenu from './AbstractMenu';
 import SubMenu from './SubMenu';
 import { hideMenu } from './actions';
-import { cssClasses, callIfExists, store } from './helpers';
+import { cssClasses, callIfExists, store, getDocumentNode } from './helpers';
 
 export default class ContextMenu extends AbstractMenu {
     static propTypes = {
@@ -87,20 +87,22 @@ export default class ContextMenu extends AbstractMenu {
     }
 
     registerHandlers = () => {
-        document.addEventListener('mousedown', this.handleOutsideClick);
-        document.addEventListener('touchstart', this.handleOutsideClick);
-        document.addEventListener('scroll', this.handleHide);
-        document.addEventListener('contextmenu', this.handleHide);
-        document.addEventListener('keydown', this.handleKeyNavigation);
+        if (this.document == null) return;
+        this.document.addEventListener('mousedown', this.handleOutsideClick);
+        this.document.addEventListener('touchstart', this.handleOutsideClick);
+        this.document.addEventListener('scroll', this.handleHide);
+        this.document.addEventListener('contextmenu', this.handleHide);
+        this.document.addEventListener('keydown', this.handleKeyNavigation);
         window.addEventListener('resize', this.handleHide);
     }
 
     unregisterHandlers = () => {
-        document.removeEventListener('mousedown', this.handleOutsideClick);
-        document.removeEventListener('touchstart', this.handleOutsideClick);
-        document.removeEventListener('scroll', this.handleHide);
-        document.removeEventListener('contextmenu', this.handleHide);
-        document.removeEventListener('keydown', this.handleKeyNavigation);
+        if (this.document == null) return;
+        this.document.removeEventListener('mousedown', this.handleOutsideClick);
+        this.document.removeEventListener('touchstart', this.handleOutsideClick);
+        this.document.removeEventListener('scroll', this.handleHide);
+        this.document.removeEventListener('contextmenu', this.handleHide);
+        this.document.removeEventListener('keydown', this.handleKeyNavigation);
         window.removeEventListener('resize', this.handleHide);
     }
 
@@ -217,6 +219,13 @@ export default class ContextMenu extends AbstractMenu {
 
     menuRef = (c) => {
         this.menu = c;
+        // Get the document fragment that contains the menu, if contained in a shadow DOM;
+        // otherwise get the page's document.  Determining the document element that applies allows
+        // us to attach document-wide events that are guaranteed to work (refer to
+        // `registerHandlers`/`unregisterHandlers`).  Note that this solves the problem we had
+        // previously when we were attaching the events to `document` regardless, which did NOT
+        // work when the menu was contained in a shadow DOM.
+        this.document = getDocumentNode(c);
     }
 
     render() {

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -87,7 +87,7 @@ export default class ContextMenu extends AbstractMenu {
     }
 
     registerHandlers = () => {
-        if (this.document == null) return;
+        if (this.document === null) return;
         this.document.addEventListener('mousedown', this.handleOutsideClick);
         this.document.addEventListener('touchstart', this.handleOutsideClick);
         this.document.addEventListener('scroll', this.handleHide);
@@ -97,7 +97,7 @@ export default class ContextMenu extends AbstractMenu {
     }
 
     unregisterHandlers = () => {
-        if (this.document == null) return;
+        if (this.document === null) return;
         this.document.removeEventListener('mousedown', this.handleOutsideClick);
         this.document.removeEventListener('touchstart', this.handleOutsideClick);
         this.document.removeEventListener('scroll', this.handleHide);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,16 +37,20 @@ export const canUseDOM = Boolean(
 //  - `null`: when node is `null`, not browser or invalid environment
 //  - `document`: if the node is NOT contained within a shadow DOM
 //  - instance of `DocumentFragment`: when the node IS contained within a shadow DOM
-export function getDocumentNode(node) {
-    while (node != null) {
+export function getDocumentNode(startingAt) {
+    let node = startingAt;
+    while (node !== null) {
         switch (node.nodeType) {
             case Node.DOCUMENT_NODE: // master document node
             case Node.DOCUMENT_FRAGMENT_NODE: // used by shadow DOM
-            return node;
+                return node;
+
+            default:
         }
 
         node = node.parentNode;
     }
 
-    return null;
+    // Return whatever document is; resolves test failures.
+    return document;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -27,3 +27,26 @@ export const store = {};
 export const canUseDOM = Boolean(
   typeof window !== 'undefined' && window.document && window.document.createElement
 );
+
+// Locate the document element that contains a specified element
+//
+// This function looks to see if the element is contained within a shadow DOM and returns the
+// appropriate document (or fragment) element that applies.  The returned node will be one of the
+// following:
+//
+//  - `null`: when node is `null`, not browser or invalid environment
+//  - `document`: if the node is NOT contained within a shadow DOM
+//  - instance of `DocumentFragment`: when the node IS contained within a shadow DOM
+export function getDocumentNode(node) {
+    while (node != null) {
+        switch (node.nodeType) {
+            case Node.DOCUMENT_NODE: // master document node
+            case Node.DOCUMENT_FRAGMENT_NODE: // used by shadow DOM
+            return node;
+        }
+
+        node = node.parentNode;
+    }
+
+    return null;
+}


### PR DESCRIPTION
This PR adds support for context menus contained within a shadow DOM.  

The code made the assumption that context menus would always be contained as part of the page's master `document` element. However, event listeners attached to `document` for the purpose of knowing when to hide the menu were found to be malfunctioning when the menu was contained within a shadow DOM. In particular, "click" events were prevented from ever being received by the menu items, causing the menu to always hide regardless.  This is now fixed in this PR. 