### PR TITLE
Add to ContextMenuTriggerProps typescript interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,6 +19,8 @@ declare module "react-contextmenu" {
         disable?: boolean,
         holdToDisplay?: number,
         renderTag?: React.ReactType,
+        mouseButton?: number,
+        disableIfShiftIsPressed?: boolean,
     }
 
     interface MenuItemProps {


### PR DESCRIPTION
Adds mouseButton and disableIfShiftIsPressed so they can be used without erroring out in Typescript projects. 

Is this correct? I've just started using this package.