### PR TITLE
Updated README.md with a warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ function MyApp() {
   return (
     <div>
 
-      <ContextMenuTrigger id="some_unique_identifier">
+      <ContextMenuTrigger id="some_unique_identifier"> {/* NOTICE: id must be unique for EVERY instance */
         <div className="well">Right click to see the menu</div>
       </ContextMenuTrigger>
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ function MyApp() {
   return (
     <div>
 
-      <ContextMenuTrigger id="some_unique_identifier"> {/* NOTICE: id must be unique for EVERY instance */
+      <ContextMenuTrigger id="some_unique_identifier"> {/* NOTICE: id must be unique for EVERY instance */}
         <div className="well">Right click to see the menu</div>
       </ContextMenuTrigger>
 


### PR DESCRIPTION
I spent a lot of time debugging the `onClick` for `MenuItem` and after trying again and again I found in the issue tracker a comment explaining that every single instance of `ContextMenu` and `ContextMenuTrigger` needs to have a unique `id` they cannot share one even if they are the same component or use the same menu. 

I think this a good change to make to the docs since it's very small and can help people prevent people from wasting time debugging. Thank you for your time.