### PR TITLE
Update ContextMenuTriggerProps to allow custom props

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,6 +25,7 @@ declare module "react-contextmenu" {
         renderTag?: React.ElementType,
         mouseButton?: number,
         disableIfShiftIsPressed?: boolean,
+        [key: string]: any
     }
 
     export interface MenuItemProps {


### PR DESCRIPTION
This allows extra props to be added to `ContextMenuTrigger`.
Unless I am completely misunderstanding how the custom props work?

Currently, if I add any custom prop to `ContextMenuTrigger` TypeScript complains about non-existent properties on `ContextMenuTriggerProps`.

Super happy to be wrong as I couldn't easily figure out how else it would work.